### PR TITLE
Add budget analytics service and endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,33 @@ BudgetManager est une application Laravel destinée au pilotage budgétaire d'un
 - **Code** : ajustements pour PHP 7.4 (`Throwable`, `Str::random`, casts Eloquent) et durcissement de la gestion d'erreurs JSON et d'authentification.
 - **Qualité** : nouveau `phpunit.xml` configuré pour SQLite en mémoire, localisation par défaut en français et activation d'un niveau de logs configurable.
 
+## Fonctionnalités essentielles
+1. **Visibilité en temps réel** : accès immédiat à l'état des budgets et des flux financiers afin d'éviter les retards ou mauvaises surprises.
+2. **Comparaison réel/prévisionnel** : outil pour confronter dépenses et recettes réelles aux prévisions, analyser les écarts et ajuster la stratégie.
+3. **Planification budgétaire** : création et gestion de budgets par catégorie, projet ou service, avec simulation de scénarios pour anticiper les évolutions.
+4. **Rapports et analyses avancés** : génération de tableaux de bord, graphiques et rapports personnalisés pour interpréter les données financières et décider rapidement.
+5. **Alertes et contrôle des dépassements** : signalement automatique en cas de risque ou de dépassement budgétaire, notamment lors des processus d'approbation.
+6. **Sécurisation des données** : protection des informations personnelles et comptables grâce à des protocoles et outils robustes.
+7. **Synchronisation bancaire** : intégration directe avec les comptes bancaires pour une mise à jour automatique et fiable des mouvements et soldes.
+8. **Interface intuitive et personnalisable** : facilité d'utilisation, adaptation à la structure de l'organisation et compatibilité avec les outils existants.
+9. **Gestion des factures et devis** : suivi des engagements, factures, impayés et relances pour maîtriser les dépenses et la trésorerie.
+10. **Scénarios et prédictions** : anticipation des évolutions, prévision de trésorerie et révisions dynamiques du budget.
+11. **Mobile et collaboration** : accès via application mobile ou web pour suivre et valider les demandes, collaborer avec les équipes et garantir la continuité opérationnelle.
+
+## API d'analyse budgétaire
+
+L'API REST fournit des points d'accès permettant d'exploiter ces fonctionnalités au travers d'intégrations tierces :
+
+| Méthode | Route | Description |
+| --- | --- | --- |
+| `GET` | `/api/budget/snapshot?exercice=2024&as_of=2024-03-31` | Retourne un instantané temps réel (prévision, réalisé, reste à consommer, projection annuelle, ventilation mensuelle). |
+| `GET` | `/api/budget/comparison?exercice=2024&start=2024-01-01&end=2024-03-31` | Compare réalisé vs prévision pour chaque poste et calcule écarts et taux de réalisation. |
+| `POST` | `/api/budget/scenario` | Simule des ajustements (`adjustments` JSON) pour piloter la planification budgétaire et mesurer l'impact d'hypothèses. |
+| `GET` | `/api/budget/alerts?exercice=2024&threshold=1.0` | Signale automatiquement les dépassements de prévision avec un niveau de sévérité. |
+| `GET` | `/api/budget/report?exercice=2024` | Génère un rapport consolidé (snapshot, comparatif, alertes, top écarts) pour alimenter tableaux de bord et exports. |
+
+Les dates (`start`, `end`, `as_of`) doivent être fournies au format ISO (`YYYY-MM-DD`). Les ajustements d'un scénario peuvent être transmis sous forme de tableau associatif (`{"601": 20000}`) ou de tableau d'objets (`[{"num_compte": "601", "delta": 20000}]`).
+
 ## Fonctionnalités suggérées
 1. **Tableau de bord analytique** : visualisation dynamique (graphiques et KPIs) des réalisations versus prévisions pour chaque exercice.
 2. **Workflow de validation** : système d'approbation multi-niveaux pour les prévisions et dépenses avec notifications par e-mail.

--- a/app/Http/Controllers/Api/BudgetAnalyticsController.php
+++ b/app/Http/Controllers/Api/BudgetAnalyticsController.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\BudgetAnalyticsService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+class BudgetAnalyticsController extends Controller
+{
+    public function snapshot(Request $request, BudgetAnalyticsService $service)
+    {
+        $exercice = $this->requireExerciceCode($request);
+        $asOf = $this->parseDate($request->query('as_of'));
+
+        return response()->json(
+            $service->getRealTimeSnapshot($exercice, $asOf)
+        );
+    }
+
+    public function comparison(Request $request, BudgetAnalyticsService $service)
+    {
+        $exercice = $this->requireExerciceCode($request);
+        [$start, $end] = $this->parseDateRange($request);
+
+        return response()->json(
+            $service->compareActualVsForecast($exercice, $start, $end)
+        );
+    }
+
+    public function report(Request $request, BudgetAnalyticsService $service)
+    {
+        $exercice = $this->requireExerciceCode($request);
+        [$start, $end] = $this->parseDateRange($request);
+
+        return response()->json(
+            $service->generateReportData($exercice, $start, $end)
+        );
+    }
+
+    public function alerts(Request $request, BudgetAnalyticsService $service)
+    {
+        $exercice = $this->requireExerciceCode($request);
+        [$start, $end] = $this->parseDateRange($request);
+        $threshold = (float) $request->query('threshold', 1.0);
+
+        return response()->json(
+            $service->detectAlerts($exercice, $threshold, $start, $end)
+        );
+    }
+
+    public function scenario(Request $request, BudgetAnalyticsService $service)
+    {
+        $exercice = $this->requireExerciceCode($request);
+        [$start, $end] = $this->parseDateRange($request);
+        $adjustments = $request->input('adjustments', []);
+
+        if (!is_array($adjustments)) {
+            return response()->json([
+                'message' => 'The adjustments payload must be an array.',
+            ], 422);
+        }
+
+        return response()->json(
+            $service->simulateScenario($exercice, $adjustments, $start, $end)
+        );
+    }
+
+    protected function requireExerciceCode(Request $request): string
+    {
+        $exercice = $request->query('exercice', $request->input('exercice'));
+
+        if (!$exercice) {
+            abort(422, 'The exercice parameter is required.');
+        }
+
+        return (string) $exercice;
+    }
+
+    protected function parseDate(?string $date): ?Carbon
+    {
+        if (!$date) {
+            return null;
+        }
+
+        return Carbon::parse($date)->startOfDay();
+    }
+
+    protected function parseDateRange(Request $request): array
+    {
+        $start = $this->parseDate($request->query('start'));
+        $end = $this->parseDate($request->query('end'));
+
+        if ($start && $end && $end->lessThan($start)) {
+            abort(422, 'The end date must be greater than or equal to the start date.');
+        }
+
+        return [$start, $end];
+    }
+}

--- a/app/PostBudgetaire.php
+++ b/app/PostBudgetaire.php
@@ -7,7 +7,13 @@ use Illuminate\Database\Eloquent\Model;
 class PostBudgetaire extends Model
 {
     protected $table = 'postbudgetaire';
-    public $timestamps = 0;
+    public $timestamps = false;
+
+    protected $fillable = [
+        'numCompte',
+        'intitulePost',
+        'isDelete',
+    ];
 
     public function isExist()
     {

--- a/app/Prevision.php
+++ b/app/Prevision.php
@@ -6,6 +6,16 @@ use Illuminate\Database\Eloquent\Model;
 
 class Prevision extends Model
 {
-    protected $table ='prevision';
-    public $timestamps = 0;
+    protected $table = 'prevision';
+
+    protected $primaryKey = 'idPrevision';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'codePostBudgetaire',
+        'exercicePrevi',
+        'montantPrevision',
+        'isDelete',
+    ];
 }

--- a/app/Realisation.php
+++ b/app/Realisation.php
@@ -1,11 +1,24 @@
 <?php
 
-namespace App\Models;
+namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 
 class Realisation extends Model
 {
-    protected $table ='prevision';
-    public $timestamps = 0;
+    protected $table = 'realisation';
+
+    protected $primaryKey = 'refferenceRea';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'montantRea',
+        'dateRea',
+        'observationRea',
+        'codePrevision',
+        'isDelete',
+        'autorise_par',
+        'effectuer_par',
+    ];
 }

--- a/app/Services/BudgetAnalyticsService.php
+++ b/app/Services/BudgetAnalyticsService.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace App\Services;
+
+use App\PostBudgetaire;
+use App\Prevision;
+use App\Realisation;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class BudgetAnalyticsService
+{
+    public function getRealTimeSnapshot(string $exerciceCode, ?Carbon $asOf = null): array
+    {
+        $asOf = $asOf?->copy()->endOfDay() ?? Carbon::now()->endOfDay();
+        $periodStart = Carbon::create($asOf->year, 1, 1)->startOfDay();
+        $periodEnd = $asOf->copy();
+
+        $totalForecast = (float) Prevision::query()
+            ->where('isDelete', 0)
+            ->where('exercicePrevi', $exerciceCode)
+            ->sum('montantPrevision');
+
+        $totalActual = (float) Realisation::query()
+            ->join('prevision', 'prevision.idPrevision', '=', 'realisation.codePrevision')
+            ->where('realisation.isDelete', 0)
+            ->where('prevision.exercicePrevi', $exerciceCode)
+            ->whereDate('dateRea', '<=', $periodEnd->toDateString())
+            ->sum('montantRea');
+
+        $daysElapsed = max(1, $periodStart->diffInDays($periodEnd) + 1);
+        $daysInPeriod = $periodStart->copy()->endOfYear()->diffInDays($periodStart) + 1;
+        $averageDailySpend = $totalActual / $daysElapsed;
+        $projectedActual = $averageDailySpend * $daysInPeriod;
+
+        $snapshot = [
+            'as_of' => $periodEnd->toDateString(),
+            'total_forecast' => $totalForecast,
+            'total_actual' => $totalActual,
+            'remaining_budget' => $totalForecast - $totalActual,
+            'completion_rate' => $totalForecast > 0 ? ($totalActual / $totalForecast) * 100 : 0.0,
+            'projected_actual' => $projectedActual,
+            'projected_variance' => $projectedActual - $totalForecast,
+            'projected_completion_rate' => $totalForecast > 0 ? ($projectedActual / $totalForecast) * 100 : 0.0,
+        ];
+
+        $snapshot['monthly_realisation'] = $this->monthlyRealisation($exerciceCode, $periodStart, $periodEnd)->toArray();
+
+        return $snapshot;
+    }
+
+    public function compareActualVsForecast(string $exerciceCode, ?Carbon $startDate = null, ?Carbon $endDate = null): array
+    {
+        $endDate = $endDate?->copy() ?? Carbon::now();
+        $startDate = $startDate?->copy() ?? $endDate->copy()->startOfYear();
+
+        $forecasts = Prevision::query()
+            ->select('codePostBudgetaire', DB::raw('SUM(montantPrevision) as forecast'))
+            ->where('isDelete', 0)
+            ->where('exercicePrevi', $exerciceCode)
+            ->groupBy('codePostBudgetaire')
+            ->get()
+            ->keyBy('codePostBudgetaire');
+
+        $actuals = Realisation::query()
+            ->select('prevision.codePostBudgetaire', DB::raw('SUM(montantRea) as actual'))
+            ->join('prevision', 'prevision.idPrevision', '=', 'realisation.codePrevision')
+            ->where('realisation.isDelete', 0)
+            ->where('prevision.exercicePrevi', $exerciceCode)
+            ->whereDate('dateRea', '>=', $startDate->toDateString())
+            ->whereDate('dateRea', '<=', $endDate->toDateString())
+            ->groupBy('prevision.codePostBudgetaire')
+            ->get()
+            ->pluck('actual', 'codePostBudgetaire');
+
+        $codes = $forecasts->keys()->merge($actuals->keys())->unique()->values();
+
+        $posts = PostBudgetaire::query()
+            ->whereIn('numCompte', $codes)
+            ->get()
+            ->keyBy('numCompte');
+
+        return $codes
+            ->map(function (string $code) use ($forecasts, $actuals, $posts) {
+                $forecastRow = $forecasts->get($code);
+                $forecast = $forecastRow ? (float) $forecastRow->forecast : 0.0;
+                $actual = (float) ($actuals[$code] ?? 0.0);
+                $variance = $forecast - $actual;
+
+                return [
+                    'num_compte' => $code,
+                    'intitule' => optional($posts->get($code))->intitulePost,
+                    'forecast' => $forecast,
+                    'actual' => $actual,
+                    'variance' => $variance,
+                    'variance_rate' => $forecast !== 0.0 ? ($variance / $forecast) * 100 : 0.0,
+                    'realisation_rate' => $forecast !== 0.0 ? ($actual / $forecast) * 100 : 0.0,
+                ];
+            })
+            ->sortByDesc('actual')
+            ->values()
+            ->toArray();
+    }
+
+    public function simulateScenario(string $exerciceCode, array $adjustments, ?Carbon $startDate = null, ?Carbon $endDate = null): array
+    {
+        $baseline = collect($this->compareActualVsForecast($exerciceCode, $startDate, $endDate))
+            ->keyBy('num_compte');
+
+        $normalized = $this->normalizeAdjustments($adjustments);
+        $codes = $baseline->keys()->merge(array_keys($normalized))->unique()->values();
+
+        $results = [];
+        $totals = [
+            'baseline_forecast' => 0.0,
+            'scenario_forecast' => 0.0,
+            'actual' => 0.0,
+            'adjustment' => 0.0,
+        ];
+
+        foreach ($codes as $code) {
+            $baselineRow = $baseline[$code] ?? [
+                'forecast' => 0.0,
+                'actual' => 0.0,
+                'intitule' => null,
+            ];
+
+            $adjustment = (float) ($normalized[$code] ?? 0.0);
+            $scenarioForecast = $baselineRow['forecast'] + $adjustment;
+            $actual = $baselineRow['actual'];
+
+            $totals['baseline_forecast'] += $baselineRow['forecast'];
+            $totals['scenario_forecast'] += $scenarioForecast;
+            $totals['actual'] += $actual;
+            $totals['adjustment'] += $adjustment;
+
+            $results[] = [
+                'num_compte' => $code,
+                'intitule' => $baselineRow['intitule'],
+                'baseline_forecast' => $baselineRow['forecast'],
+                'actual' => $actual,
+                'adjustment' => $adjustment,
+                'scenario_forecast' => $scenarioForecast,
+                'scenario_remaining' => $scenarioForecast - $actual,
+                'scenario_rate' => $scenarioForecast !== 0.0 ? ($actual / $scenarioForecast) * 100 : 0.0,
+            ];
+        }
+
+        $totals['baseline_remaining'] = $totals['baseline_forecast'] - $totals['actual'];
+        $totals['scenario_remaining'] = $totals['scenario_forecast'] - $totals['actual'];
+
+        return [
+            'lines' => $results,
+            'totals' => $totals,
+        ];
+    }
+
+    public function detectAlerts(string $exerciceCode, float $threshold = 1.0, ?Carbon $startDate = null, ?Carbon $endDate = null): array
+    {
+        $comparisons = $this->compareActualVsForecast($exerciceCode, $startDate, $endDate);
+
+        return collect($comparisons)
+            ->filter(function (array $line) use ($threshold) {
+                if ($line['forecast'] <= 0.0) {
+                    return false;
+                }
+
+                $ratio = $line['actual'] / $line['forecast'];
+
+                return $ratio >= $threshold;
+            })
+            ->map(function (array $line) {
+                $ratio = $line['forecast'] > 0 ? $line['actual'] / $line['forecast'] : 0;
+
+                return array_merge($line, [
+                    'severity' => $this->classifySeverity($ratio),
+                    'overrun' => $line['actual'] - $line['forecast'],
+                ]);
+            })
+            ->values()
+            ->toArray();
+    }
+
+    public function generateReportData(string $exerciceCode, ?Carbon $startDate = null, ?Carbon $endDate = null): array
+    {
+        $asOf = $endDate?->copy() ?? Carbon::now();
+        $snapshot = $this->getRealTimeSnapshot($exerciceCode, $asOf);
+        $comparison = $this->compareActualVsForecast($exerciceCode, $startDate, $endDate ?? $asOf);
+
+        return [
+            'snapshot' => $snapshot,
+            'comparison' => $comparison,
+            'alerts' => $this->detectAlerts($exerciceCode, 1.0, $startDate, $endDate ?? $asOf),
+            'top_variances' => collect($comparison)
+                ->sortBy('variance')
+                ->take(5)
+                ->values()
+                ->toArray(),
+        ];
+    }
+
+    protected function monthlyRealisation(string $exerciceCode, Carbon $start, Carbon $end): Collection
+    {
+        $expression = $this->monthExpression('dateRea');
+
+        return Realisation::query()
+            ->selectRaw($expression . ' as period, SUM(montantRea) as total')
+            ->join('prevision', 'prevision.idPrevision', '=', 'realisation.codePrevision')
+            ->where('realisation.isDelete', 0)
+            ->where('prevision.exercicePrevi', $exerciceCode)
+            ->whereDate('dateRea', '>=', $start->toDateString())
+            ->whereDate('dateRea', '<=', $end->toDateString())
+            ->groupBy('period')
+            ->orderBy('period')
+            ->get()
+            ->pluck('total', 'period');
+    }
+
+    protected function monthExpression(string $column): string
+    {
+        return match (DB::connection()->getDriverName()) {
+            'sqlite' => "strftime('%Y-%m', $column)",
+            'pgsql' => "to_char($column, 'YYYY-MM')",
+            default => "DATE_FORMAT($column, '%Y-%m')",
+        };
+    }
+
+    protected function normalizeAdjustments(array $adjustments): array
+    {
+        $normalized = [];
+
+        foreach ($adjustments as $key => $value) {
+            if (is_array($value) && isset($value['num_compte'])) {
+                $delta = $value['delta'] ?? $value['adjustment'] ?? 0;
+                $normalized[$value['num_compte']] = (float) $delta;
+                continue;
+            }
+
+            if (is_string($key)) {
+                $normalized[$key] = (float) $value;
+                continue;
+            }
+        }
+
+        return $normalized;
+    }
+
+    protected function classifySeverity(float $ratio): string
+    {
+        if ($ratio >= 1.2) {
+            return 'critical';
+        }
+
+        if ($ratio >= 1.0) {
+            return 'warning';
+        }
+
+        return 'info';
+    }
+}

--- a/database/migrations/2024_03_10_000000_create_budget_core_tables.php
+++ b/database/migrations/2024_03_10_000000_create_budget_core_tables.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('postbudgetaire', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('numCompte')->unique();
+            $table->string('intitulePost')->nullable();
+            $table->boolean('isDelete')->default(false);
+            $table->timestamps();
+        });
+
+        Schema::create('prevision', function (Blueprint $table) {
+            $table->bigIncrements('idPrevision');
+            $table->string('codePostBudgetaire');
+            $table->string('exercicePrevi');
+            $table->decimal('montantPrevision', 15, 2);
+            $table->boolean('isDelete')->default(false);
+            $table->timestamps();
+
+            $table->foreign('codePostBudgetaire')->references('numCompte')->on('postbudgetaire');
+        });
+
+        Schema::create('realisation', function (Blueprint $table) {
+            $table->bigIncrements('refferenceRea');
+            $table->decimal('montantRea', 15, 2);
+            $table->date('dateRea');
+            $table->text('observationRea')->nullable();
+            $table->unsignedBigInteger('codePrevision');
+            $table->boolean('isDelete')->default(false);
+            $table->string('autorise_par')->nullable();
+            $table->string('effectuer_par')->nullable();
+            $table->timestamps();
+
+            $table->foreign('codePrevision')->references('idPrevision')->on('prevision');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('realisation');
+        Schema::dropIfExists('prevision');
+        Schema::dropIfExists('postbudgetaire');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Http\Request;
+use App\Http\Controllers\Api\BudgetAnalyticsController;
 
 /*
 |--------------------------------------------------------------------------
@@ -18,7 +19,15 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 });
 
 
-Route::get('/test', function (){
-    $users = array('login' =>"rapha" ,  "password"=>"test");
-       return response()->json($users);
+Route::get('/test', function () {
+    $users = array('login' => "rapha",  "password" => "test");
+    return response()->json($users);
+});
+
+Route::prefix('budget')->group(function () {
+    Route::get('snapshot', [BudgetAnalyticsController::class, 'snapshot']);
+    Route::get('comparison', [BudgetAnalyticsController::class, 'comparison']);
+    Route::get('report', [BudgetAnalyticsController::class, 'report']);
+    Route::get('alerts', [BudgetAnalyticsController::class, 'alerts']);
+    Route::post('scenario', [BudgetAnalyticsController::class, 'scenario']);
 });

--- a/tests/Feature/BudgetAnalyticsApiTest.php
+++ b/tests/Feature/BudgetAnalyticsApiTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\PostBudgetaire;
+use App\Prevision;
+use App\Realisation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BudgetAnalyticsApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_snapshot_endpoint_returns_snapshot_data(): void
+    {
+        $this->seedBudgetData();
+
+        $response = $this->getJson('/api/budget/snapshot?exercice=2024&as_of=2024-03-31');
+
+        $response->assertOk();
+        $response->assertJsonFragment([
+            'as_of' => '2024-03-31',
+            'total_forecast' => 300000.0,
+        ]);
+    }
+
+    public function test_scenario_endpoint_accepts_adjustments_payload(): void
+    {
+        $this->seedBudgetData();
+
+        $response = $this->postJson('/api/budget/scenario', [
+            'exercice' => '2024',
+            'adjustments' => [
+                ['num_compte' => '601', 'delta' => 1000],
+            ],
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('totals.scenario_forecast', 301000.0);
+    }
+
+    private function seedBudgetData(): void
+    {
+        $post1 = PostBudgetaire::create([
+            'numCompte' => '601',
+            'intitulePost' => 'Operations',
+            'isDelete' => 0,
+        ]);
+
+        $post2 = PostBudgetaire::create([
+            'numCompte' => '602',
+            'intitulePost' => 'Marketing',
+            'isDelete' => 0,
+        ]);
+
+        $prevision1 = Prevision::create([
+            'codePostBudgetaire' => $post1->numCompte,
+            'exercicePrevi' => '2024',
+            'montantPrevision' => 200000,
+            'isDelete' => 0,
+        ]);
+
+        $prevision2 = Prevision::create([
+            'codePostBudgetaire' => $post2->numCompte,
+            'exercicePrevi' => '2024',
+            'montantPrevision' => 100000,
+            'isDelete' => 0,
+        ]);
+
+        Realisation::create([
+            'montantRea' => 100000,
+            'dateRea' => '2024-01-10',
+            'observationRea' => 'Initial spend',
+            'codePrevision' => $prevision1->idPrevision,
+            'isDelete' => 0,
+        ]);
+
+        Realisation::create([
+            'montantRea' => 20000,
+            'dateRea' => '2024-02-01',
+            'observationRea' => 'Marketing spend',
+            'codePrevision' => $prevision2->idPrevision,
+            'isDelete' => 0,
+        ]);
+    }
+}

--- a/tests/Feature/BudgetAnalyticsServiceTest.php
+++ b/tests/Feature/BudgetAnalyticsServiceTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\PostBudgetaire;
+use App\Prevision;
+use App\Realisation;
+use App\Services\BudgetAnalyticsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class BudgetAnalyticsServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow(Carbon::create(2024, 3, 31));
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_snapshot_returns_expected_metrics(): void
+    {
+        $this->seedBudgetData();
+
+        $service = app(BudgetAnalyticsService::class);
+        $snapshot = $service->getRealTimeSnapshot('2024', Carbon::create(2024, 3, 31));
+
+        $this->assertSame('2024-03-31', $snapshot['as_of']);
+        $this->assertEquals(300000.0, $snapshot['total_forecast']);
+        $this->assertEquals(150000.0, $snapshot['total_actual']);
+        $this->assertEquals(150000.0, $snapshot['remaining_budget']);
+        $this->assertEqualsWithDelta(50.0, $snapshot['completion_rate'], 0.01);
+        $this->assertArrayHasKey('monthly_realisation', $snapshot);
+        $this->assertCount(3, $snapshot['monthly_realisation']);
+    }
+
+    public function test_comparison_summarises_prevision_and_realisation(): void
+    {
+        $this->seedBudgetData();
+
+        $service = app(BudgetAnalyticsService::class);
+        $comparison = $service->compareActualVsForecast('2024', Carbon::create(2024, 1, 1), Carbon::create(2024, 3, 31));
+
+        $this->assertCount(2, $comparison);
+        $first = collect($comparison)->firstWhere('num_compte', '601');
+        $this->assertEquals(200000.0, $first['forecast']);
+        $this->assertEquals(120000.0, $first['actual']);
+        $this->assertEquals(80000.0, $first['variance']);
+    }
+
+    public function test_scenario_simulation_applies_adjustments(): void
+    {
+        $this->seedBudgetData();
+
+        $service = app(BudgetAnalyticsService::class);
+        $scenario = $service->simulateScenario('2024', [
+            '601' => 20000,
+            ['num_compte' => '602', 'delta' => -5000],
+        ]);
+
+        $totals = $scenario['totals'];
+        $this->assertEquals(300000.0, $totals['baseline_forecast']);
+        $this->assertEquals(315000.0, $totals['scenario_forecast']);
+        $this->assertEquals(150000.0, $totals['actual']);
+        $this->assertEquals(15000.0, $totals['adjustment']);
+
+        $line = collect($scenario['lines'])->firstWhere('num_compte', '601');
+        $this->assertEquals(220000.0, $line['scenario_forecast']);
+    }
+
+    public function test_alert_detection_flags_threshold_breaches(): void
+    {
+        $this->seedBudgetData();
+
+        // Additional realisation to push account 602 over forecast
+        Realisation::create([
+            'montantRea' => 90000,
+            'dateRea' => '2024-03-25',
+            'observationRea' => 'Extra spend',
+            'codePrevision' => Prevision::where('codePostBudgetaire', '602')->first()->idPrevision,
+            'isDelete' => 0,
+        ]);
+
+        $service = app(BudgetAnalyticsService::class);
+        $alerts = $service->detectAlerts('2024');
+
+        $this->assertNotEmpty($alerts);
+        $overrun = collect($alerts)->firstWhere('num_compte', '602');
+        $this->assertSame('critical', $overrun['severity']);
+        $this->assertGreaterThan(0, $overrun['overrun']);
+    }
+
+    public function test_report_compiles_snapshot_comparison_and_alerts(): void
+    {
+        $this->seedBudgetData();
+
+        $service = app(BudgetAnalyticsService::class);
+        $report = $service->generateReportData('2024');
+
+        $this->assertArrayHasKey('snapshot', $report);
+        $this->assertArrayHasKey('comparison', $report);
+        $this->assertArrayHasKey('alerts', $report);
+        $this->assertArrayHasKey('top_variances', $report);
+    }
+
+    private function seedBudgetData(): void
+    {
+        PostBudgetaire::create([
+            'numCompte' => '601',
+            'intitulePost' => 'Operations',
+            'isDelete' => 0,
+        ]);
+
+        PostBudgetaire::create([
+            'numCompte' => '602',
+            'intitulePost' => 'Marketing',
+            'isDelete' => 0,
+        ]);
+
+        $prevision601 = Prevision::create([
+            'codePostBudgetaire' => '601',
+            'exercicePrevi' => '2024',
+            'montantPrevision' => 200000,
+            'isDelete' => 0,
+        ]);
+
+        $prevision602 = Prevision::create([
+            'codePostBudgetaire' => '602',
+            'exercicePrevi' => '2024',
+            'montantPrevision' => 100000,
+            'isDelete' => 0,
+        ]);
+
+        Realisation::create([
+            'montantRea' => 70000,
+            'dateRea' => '2024-01-15',
+            'observationRea' => 'January spend',
+            'codePrevision' => $prevision601->idPrevision,
+            'isDelete' => 0,
+        ]);
+
+        Realisation::create([
+            'montantRea' => 50000,
+            'dateRea' => '2024-02-10',
+            'observationRea' => 'February spend',
+            'codePrevision' => $prevision601->idPrevision,
+            'isDelete' => 0,
+        ]);
+
+        Realisation::create([
+            'montantRea' => 30000,
+            'dateRea' => '2024-03-05',
+            'observationRea' => 'March spend',
+            'codePrevision' => $prevision602->idPrevision,
+            'isDelete' => 0,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `BudgetAnalyticsService` with REST endpoints for real-time snapshots, comparisons, scenarios, alerts, and consolidated reports
- add fillable Eloquent models plus supporting migrations for postbudgetaire, prevision, and realisation data
- cover the analytics logic with feature tests and document the new API usage in the README

## Testing
- phpunit *(fails: phpunit command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ffea6f6e74832b9bf54d420064c846